### PR TITLE
Fixed SIGSEGV

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,10 +195,6 @@ func executeHTTPRequest(urlStr string, methodType string, authKey string) (b []b
 
 	defer cleanUp(resp)
 
-	if resp == nil {
-		return nil, http.StatusInternalServerError, transactionID, fmt.Errorf("Response was nil for url: %s", urlStr)
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		return nil, resp.StatusCode, transactionID, fmt.Errorf("Connecting to %s was not successful. Status: %d", urlStr, resp.StatusCode)
 	}


### PR DESCRIPTION
Issue snippet:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x564c946a6429]

goroutine 851776 [running]:
main.executeHTTPRequest(0xc4260a65b0, 0x67, 0x564c946a826e, 0x4, 0xc420bcd110, 0x24, 0xc4200160b0, 0xa, 0x0, 0x0, ...)
	/gopath/src/github.com/Financial-Times/endpoint-hitter/main.go:193 +0x569
main.hitEndpoint.func1(0xc4263dfcd0, 0x7ffd0c98579b, 0x49, 0x564c946a826e, 0x4, 0xc4200160b0, 0xa, 0xc420bcd110, 0x24)
	/gopath/src/github.com/Financial-Times/endpoint-hitter/main.go:167 +0x11a
created by main.hitEndpoint
	/gopath/src/github.com/Financial-Times/endpoint-hitter/main.go:169 +0x2dc
```

The response can be nil sometimes.